### PR TITLE
Refactor edge label positioning

### DIFF
--- a/lib/GraphView.dart
+++ b/lib/GraphView.dart
@@ -1023,6 +1023,8 @@ class RenderCustomLayoutBox extends RenderBox
   void paint(PaintingContext context, Offset offset) {
     if (_children.isEmpty && _edgeLabels.isEmpty) return;
 
+    algorithm.renderer?.setHasEdgeLabelBuilder(_edgeLabelBuilder != null);
+
     if (enableAnimation) {
       final t = _nodeAnimationController.value;
       animatedPositions.clear();
@@ -1317,6 +1319,8 @@ class RenderCustomLayoutBox extends RenderBox
   }
 
   void _layoutEdgeLabels(BoxConstraints constraints) {
+    algorithm.renderer?.setHasEdgeLabelBuilder(_edgeLabelBuilder != null);
+
     if (_edgeLabelBuilder == null) {
       return;
     }
@@ -1350,27 +1354,35 @@ class RenderCustomLayoutBox extends RenderBox
 
   Offset _edgeLabelOffsetFor(Edge edge, RenderBox child,
       {Map<Node, Offset>? positions}) {
-    Offset sourcePosition = positions?[edge.source] ?? edge.source.position;
-    Offset destinationPosition =
-        positions?[edge.destination] ?? edge.destination.position;
+    final renderer = algorithm.renderer;
+    Offset? position = renderer?.getLabelPosition(edge);
 
-    final sourceCenter = Offset(
-      sourcePosition.dx + edge.source.width * 0.5,
-      sourcePosition.dy + edge.source.height * 0.5,
-    );
-    final destinationCenter = Offset(
-      destinationPosition.dx + edge.destination.width * 0.5,
-      destinationPosition.dy + edge.destination.height * 0.5,
-    );
+    if (position == null) {
+      Offset sourcePosition = positions?[edge.source] ?? edge.source.position;
+      Offset destinationPosition =
+          positions?[edge.destination] ?? edge.destination.position;
 
-    final t = edge.labelPosition;
-    final center = Offset(
-      sourceCenter.dx + (destinationCenter.dx - sourceCenter.dx) * t,
-      sourceCenter.dy + (destinationCenter.dy - sourceCenter.dy) * t,
-    ) +
-        edge.labelOffset;
+      final sourceCenter = Offset(
+        sourcePosition.dx + edge.source.width * 0.5,
+        sourcePosition.dy + edge.source.height * 0.5,
+      );
+      final destinationCenter = Offset(
+        destinationPosition.dx + edge.destination.width * 0.5,
+        destinationPosition.dy + edge.destination.height * 0.5,
+      );
 
-    return center -
+      final t = edge.labelPosition;
+      position = Offset(
+        sourceCenter.dx + (destinationCenter.dx - sourceCenter.dx) * t,
+        sourceCenter.dy + (destinationCenter.dy - sourceCenter.dy) * t,
+      );
+    }
+
+    position ??= Offset.zero;
+
+    final adjustedCenter = position + edge.labelOffset;
+
+    return adjustedCenter -
         Offset(child.size.width * 0.5, child.size.height * 0.5);
   }
 

--- a/lib/edgerenderer/ArrowEdgeRenderer.dart
+++ b/lib/edgerenderer/ArrowEdgeRenderer.dart
@@ -25,48 +25,17 @@ class ArrowEdgeRenderer extends EdgeRenderer {
 
   @override
   void renderEdge(Canvas canvas, Edge edge, Paint paint) {
-    var source = edge.source;
-    var destination = edge.destination;
-
-    var sourceOffset = getNodePosition(source);
-    var destinationOffset = getNodePosition(destination);
-
-    var startX = sourceOffset.dx + source.width * 0.5;
-    var startY = sourceOffset.dy + source.height * 0.5;
-    var stopX = destinationOffset.dx + destination.width * 0.5;
-    var stopY = destinationOffset.dy + destination.height * 0.5;
-
-    var clippedLine = clipLineEnd(
-      startX,
-      startY,
-      stopX,
-      stopY,
-      destinationOffset.dx,
-      destinationOffset.dy,
-      destination.width,
-      destination.height,
-    );
-
+    final geometry = _buildLineGeometry(edge);
     final currentPaint = edge.paint ?? paint;
-    final startPoint = Offset(clippedLine[0], clippedLine[1]);
-    late final Offset endPoint;
+    final lineType = _getLineType(edge.destination);
 
-    if (noArrow) {
-      // Draw line without arrow, respecting line type
-      endPoint = Offset(clippedLine[2], clippedLine[3]);
-      drawStyledLine(
-        canvas,
-        startPoint,
-        endPoint,
-        currentPaint,
-        lineType: _getLineType(destination),
-      );
-    } else {
+    Offset endPoint = geometry.end;
+
+    if (!noArrow && geometry.triangleStart != null && geometry.triangleTip != null) {
       var trianglePaint = Paint()
         ..color = paint.color
         ..style = PaintingStyle.fill;
 
-      // Draw line with arrow
       Paint? edgeTrianglePaint;
       if (edge.paint != null) {
         edgeTrianglePaint = Paint()
@@ -74,27 +43,25 @@ class ArrowEdgeRenderer extends EdgeRenderer {
           ..style = PaintingStyle.fill;
       }
 
-      var triangleCentroid = drawTriangle(
+      endPoint = drawTriangle(
         canvas,
         edgeTrianglePaint ?? trianglePaint,
-        clippedLine[0],
-        clippedLine[1],
-        clippedLine[2],
-        clippedLine[3],
+        geometry.triangleStart!.dx,
+        geometry.triangleStart!.dy,
+        geometry.triangleTip!.dx,
+        geometry.triangleTip!.dy,
       );
-
-      // Draw the line with the appropriate style
-      drawStyledLine(
-        canvas,
-        startPoint,
-        triangleCentroid,
-        currentPaint,
-        lineType: _getLineType(destination),
-      );
-      endPoint = triangleCentroid;
     }
 
-    paintLabelOnLine(canvas, edge, startPoint, endPoint);
+    drawStyledLine(
+      canvas,
+      geometry.start,
+      endPoint,
+      currentPaint,
+      lineType: lineType,
+    );
+
+    paintLabelOnLine(canvas, edge, geometry.start, endPoint);
   }
 
   /// Helper to get line type from node data if available
@@ -115,33 +82,110 @@ class ArrowEdgeRenderer extends EdgeRenderer {
     double arrowTipX,
     double arrowTipY,
   ) {
-    // Calculate direction from line start to arrow tip, then flip 180° to point backwards from tip
-    var lineDirection =
-        (atan2(arrowTipY - lineStartY, arrowTipX - lineStartX) + pi);
+    final geometry = _computeTriangleGeometry(
+      lineStartX,
+      lineStartY,
+      arrowTipX,
+      arrowTipY,
+    );
 
-    // Calculate the two base points of the arrowhead triangle
-    var leftWingX =
-        (arrowTipX + ARROW_LENGTH * cos((lineDirection - ARROW_DEGREES)));
-    var leftWingY =
-        (arrowTipY + ARROW_LENGTH * sin((lineDirection - ARROW_DEGREES)));
-    var rightWingX =
-        (arrowTipX + ARROW_LENGTH * cos((lineDirection + ARROW_DEGREES)));
-    var rightWingY =
-        (arrowTipY + ARROW_LENGTH * sin((lineDirection + ARROW_DEGREES)));
-
-    // Draw the triangle: tip -> left wing -> right wing -> back to tip
     trianglePath.moveTo(arrowTipX, arrowTipY); // Arrow tip
-    trianglePath.lineTo(leftWingX, leftWingY); // Left wing
-    trianglePath.lineTo(rightWingX, rightWingY); // Right wing
+    trianglePath.lineTo(geometry.leftWing.dx, geometry.leftWing.dy); // Left wing
+    trianglePath.lineTo(geometry.rightWing.dx, geometry.rightWing.dy); // Right wing
     trianglePath.close(); // Back to tip
     canvas.drawPath(trianglePath, paint);
 
-    // Calculate center point of the triangle
-    var triangleCenterX = (arrowTipX + leftWingX + rightWingX) / 3;
-    var triangleCenterY = (arrowTipY + leftWingY + rightWingY) / 3;
-
     trianglePath.reset();
-    return Offset(triangleCenterX, triangleCenterY);
+    return geometry.centroid;
+  }
+
+  _TriangleGeometry _computeTriangleGeometry(
+    double lineStartX,
+    double lineStartY,
+    double arrowTipX,
+    double arrowTipY,
+  ) {
+    final lineDirection =
+        (atan2(arrowTipY - lineStartY, arrowTipX - lineStartX) + pi);
+
+    final leftWing = Offset(
+      arrowTipX + ARROW_LENGTH * cos((lineDirection - ARROW_DEGREES)),
+      arrowTipY + ARROW_LENGTH * sin((lineDirection - ARROW_DEGREES)),
+    );
+    final rightWing = Offset(
+      arrowTipX + ARROW_LENGTH * cos((lineDirection + ARROW_DEGREES)),
+      arrowTipY + ARROW_LENGTH * sin((lineDirection + ARROW_DEGREES)),
+    );
+
+    final centroid = Offset(
+      (arrowTipX + leftWing.dx + rightWing.dx) / 3,
+      (arrowTipY + leftWing.dy + rightWing.dy) / 3,
+    );
+
+    return _TriangleGeometry(
+      leftWing: leftWing,
+      rightWing: rightWing,
+      centroid: centroid,
+    );
+  }
+
+  _LineGeometry _buildLineGeometry(Edge edge) {
+    final source = edge.source;
+    final destination = edge.destination;
+
+    final sourceOffset = getNodePosition(source);
+    final destinationOffset = getNodePosition(destination);
+
+    final startX = sourceOffset.dx + source.width * 0.5;
+    final startY = sourceOffset.dy + source.height * 0.5;
+    final stopX = destinationOffset.dx + destination.width * 0.5;
+    final stopY = destinationOffset.dy + destination.height * 0.5;
+
+    final clippedLine = clipLineEnd(
+      startX,
+      startY,
+      stopX,
+      stopY,
+      destinationOffset.dx,
+      destinationOffset.dy,
+      destination.width,
+      destination.height,
+    );
+
+    final startPoint = Offset(clippedLine[0], clippedLine[1]);
+
+    if (noArrow) {
+      return _LineGeometry(
+        start: startPoint,
+        end: Offset(clippedLine[2], clippedLine[3]),
+      );
+    }
+
+    final triangleStart = Offset(clippedLine[0], clippedLine[1]);
+    final triangleTip = Offset(clippedLine[2], clippedLine[3]);
+    final centroid = _computeTriangleGeometry(
+      triangleStart.dx,
+      triangleStart.dy,
+      triangleTip.dx,
+      triangleTip.dy,
+    ).centroid;
+
+    return _LineGeometry(
+      start: startPoint,
+      end: centroid,
+      triangleStart: triangleStart,
+      triangleTip: triangleTip,
+    );
+  }
+
+  @override
+  Offset? getLabelPosition(Edge edge) {
+    final geometry = _buildLineGeometry(edge);
+    return resolveLabelPosition(
+      edge,
+      start: geometry.start,
+      end: geometry.end,
+    );
   }
 
   List<double> clipLineEnd(
@@ -249,4 +293,30 @@ class ArrowEdgeRenderer extends EdgeRenderer {
 
     return resultLine;
   }
+}
+
+class _TriangleGeometry {
+  final Offset leftWing;
+  final Offset rightWing;
+  final Offset centroid;
+
+  const _TriangleGeometry({
+    required this.leftWing,
+    required this.rightWing,
+    required this.centroid,
+  });
+}
+
+class _LineGeometry {
+  final Offset start;
+  final Offset end;
+  final Offset? triangleStart;
+  final Offset? triangleTip;
+
+  const _LineGeometry({
+    required this.start,
+    required this.end,
+    this.triangleStart,
+    this.triangleTip,
+  });
 }

--- a/lib/edgerenderer/EdgeRenderer.dart
+++ b/lib/edgerenderer/EdgeRenderer.dart
@@ -2,6 +2,7 @@ part of graphview;
 
 abstract class EdgeRenderer {
   Map<Node, Offset>? _animatedPositions;
+  bool _hasEdgeLabelBuilder = false;
 
   static const TextStyle _defaultLabelStyle = TextStyle(
     color: Colors.black,
@@ -11,64 +12,91 @@ abstract class EdgeRenderer {
   void setAnimatedPositions(Map<Node, Offset> positions) =>
       _animatedPositions = positions;
 
+  void setHasEdgeLabelBuilder(bool value) =>
+      _hasEdgeLabelBuilder = value;
+
   Offset getNodePosition(Node node) =>
       _animatedPositions?[node] ?? node.position;
 
   void renderEdge(Canvas canvas, Edge edge, Paint paint);
 
   void paintLabelOnLine(Canvas canvas, Edge edge, Offset start, Offset end) {
-    final label = edge.label;
-    if (label == null || label.isEmpty) return;
-
-    final t = edge.labelPosition;
-    final position = Offset(
-      start.dx + (end.dx - start.dx) * t,
-      start.dy + (end.dy - start.dy) * t,
+    final position = resolveLabelPosition(
+      edge,
+      start: start,
+      end: end,
     );
+    if (position == null) return;
 
-    _paintLabel(canvas, edge, position);
+    if (!_hasEdgeLabelBuilder) {
+      _paintLabel(canvas, edge, position);
+    }
   }
 
   void paintLabelOnPath(Canvas canvas, Edge edge, Path path) {
-    final label = edge.label;
-    if (label == null || label.isEmpty) return;
-
-    final metrics = path.computeMetrics().toList();
-    if (metrics.isEmpty) return;
-
-    final totalLength = metrics.fold<double>(
-      0.0,
-      (sum, metric) => sum + metric.length,
-    );
-    if (totalLength == 0.0) {
-      final fallbackTangent = metrics.first.getTangentForOffset(0);
-      if (fallbackTangent == null) return;
-      _paintLabel(canvas, edge, fallbackTangent.position);
-      return;
-    }
-
-    final target = totalLength * edge.labelPosition;
-    var traversed = 0.0;
-    Offset? position;
-
-    for (final metric in metrics) {
-      final nextTraversed = traversed + metric.length;
-      if (target <= nextTraversed) {
-        final localOffset = (target - traversed).clamp(0.0, metric.length);
-        final tangent = metric.getTangentForOffset(localOffset.toDouble());
-        if (tangent != null) {
-          position = tangent.position;
-        }
-        break;
-      }
-      traversed = nextTraversed;
-    }
-
-    position ??=
-        metrics.last.getTangentForOffset(metrics.last.length)?.position;
+    final position = resolveLabelPosition(edge, path: path);
     if (position == null) return;
 
-    _paintLabel(canvas, edge, position);
+    if (!_hasEdgeLabelBuilder) {
+      _paintLabel(canvas, edge, position);
+    }
+  }
+
+  Offset? resolveLabelPosition(
+    Edge edge, {
+    Offset? start,
+    Offset? end,
+    Path? path,
+  }) {
+    if (!_hasEdgeLabelBuilder) {
+      final label = edge.label;
+      if (label == null || label.isEmpty) return null;
+    }
+
+    if (path != null) {
+      final metrics = path.computeMetrics().toList();
+      if (metrics.isEmpty) return null;
+
+      final totalLength = metrics.fold<double>(
+        0.0,
+        (sum, metric) => sum + metric.length,
+      );
+      if (totalLength == 0.0) {
+        final fallbackTangent = metrics.first.getTangentForOffset(0);
+        return fallbackTangent?.position;
+      }
+
+      final target = totalLength * edge.labelPosition;
+      var traversed = 0.0;
+      Offset? position;
+
+      for (final metric in metrics) {
+        final nextTraversed = traversed + metric.length;
+        if (target <= nextTraversed) {
+          final localOffset = (target - traversed).clamp(0.0, metric.length);
+          final tangent = metric.getTangentForOffset(localOffset.toDouble());
+          if (tangent != null) {
+            position = tangent.position;
+          }
+          break;
+        }
+        traversed = nextTraversed;
+      }
+
+      position ??=
+          metrics.last.getTangentForOffset(metrics.last.length)?.position;
+      return position;
+    }
+
+    if (start != null && end != null) {
+      final t = edge.labelPosition;
+      return Offset(
+        start.dx + (end.dx - start.dx) * t,
+        start.dy + (end.dy - start.dy) * t,
+      );
+    }
+
+    return null;
   }
 
   void _paintLabel(Canvas canvas, Edge edge, Offset position) {
@@ -100,6 +128,8 @@ abstract class EdgeRenderer {
       nodePosition.dy + node.height * 0.5,
     );
   }
+
+  Offset? getLabelPosition(Edge edge) => null;
 
   /// Draws a line between two points respecting the node's line type
   void drawStyledLine(

--- a/lib/layered/SugiyamaEdgeRenderer.dart
+++ b/lib/layered/SugiyamaEdgeRenderer.dart
@@ -5,8 +5,6 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
   Map<Edge, SugiyamaEdgeData> edgeData;
   BendPointShape bendPointShape;
   bool addTriangleToEdge;
-  var path = Path();
-
   SugiyamaEdgeRenderer(
     this.nodeData,
     this.edgeData,
@@ -63,57 +61,107 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
     Paint currentPaint,
     Paint trianglePaint,
   ) {
+    final result = _buildBendPath(edge);
+
+    if (addTriangleToEdge &&
+        result.triangleStart != null &&
+        result.triangleTip != null) {
+      drawTriangle(
+        canvas,
+        trianglePaint,
+        result.triangleStart!.dx,
+        result.triangleStart!.dy,
+        result.triangleTip!.dx,
+        result.triangleTip!.dy,
+      );
+    }
+
+    canvas.drawPath(result.path, currentPaint);
+    paintLabelOnPath(canvas, edge, result.path);
+  }
+
+  void _renderStraightEdge(
+    Canvas canvas,
+    Edge edge,
+    Paint currentPaint,
+    Paint trianglePaint,
+  ) {
+    final geometry = _computeStraightEdgeGeometry(edge);
+    Offset endPoint = geometry.end;
+
+    if (addTriangleToEdge &&
+        geometry.triangleStart != null &&
+        geometry.triangleTip != null) {
+      endPoint = drawTriangle(
+        canvas,
+        trianglePaint,
+        geometry.triangleStart!.dx,
+        geometry.triangleStart!.dy,
+        geometry.triangleTip!.dx,
+        geometry.triangleTip!.dy,
+      );
+    }
+
+    final lineType = nodeData[edge.destination]?.lineType;
+    drawStyledLine(
+      canvas,
+      geometry.start,
+      endPoint,
+      currentPaint,
+      lineType: lineType,
+    );
+    paintLabelOnLine(canvas, edge, geometry.start, endPoint);
+  }
+
+  _BendPathResult _buildBendPath(Edge edge) {
     final source = edge.source;
     final destination = edge.destination;
-    var bendPoints = edgeData[edge]!.bendPoints;
+    final bendPoints = edgeData[edge]!.bendPoints;
 
-    var sourceCenter = _getNodeCenter(source);
-
-    // Calculate the transition/offset from the original bend point to animated position
+    final sourceCenter = _getNodeCenter(source);
     final transitionDx = sourceCenter.dx - bendPoints[0];
     final transitionDy = sourceCenter.dy - bendPoints[1];
 
-    path.reset();
-    path.moveTo(sourceCenter.dx, sourceCenter.dy);
-
+    final path = Path()..moveTo(sourceCenter.dx, sourceCenter.dy);
     final bendPointsWithoutDuplication = <Offset>[];
 
     for (var i = 0; i < bendPoints.length; i += 2) {
       final isLastPoint = i == bendPoints.length - 2;
 
-      // Apply the same transition to all bend points
       final x = bendPoints[i] + transitionDx;
       final y = bendPoints[i + 1] + transitionDy;
       final x2 = isLastPoint ? -1 : bendPoints[i + 2] + transitionDx;
       final y2 = isLastPoint ? -1 : bendPoints[i + 3] + transitionDy;
 
       if (x == x2 && y == y2) {
-        // Skip when two consecutive points are identical
-        // because drawing a line between would be redundant in this case.
         continue;
       }
       bendPointsWithoutDuplication.add(Offset(x, y));
     }
 
     if (bendPointShape is MaxCurvedBendPointShape) {
-      _drawMaxCurvedBendPointsEdge(bendPointsWithoutDuplication);
+      _drawMaxCurvedBendPointsEdge(path, bendPointsWithoutDuplication);
     } else if (bendPointShape is CurvedBendPointShape) {
       final shape = bendPointShape as CurvedBendPointShape;
       _drawCurvedBendPointsEdge(
+        path,
         bendPointsWithoutDuplication,
         shape.curveLength,
       );
     } else {
-      _drawSharpBendPointsEdge(bendPointsWithoutDuplication);
+      _drawSharpBendPointsEdge(path, bendPointsWithoutDuplication);
     }
 
-    var descOffset = getNodePosition(destination);
-    var stopX = descOffset.dx + destination.width * 0.5;
-    var stopY = descOffset.dy + destination.height * 0.5;
+    final descOffset = getNodePosition(destination);
+    final stopX = descOffset.dx + destination.width * 0.5;
+    final stopY = descOffset.dy + destination.height * 0.5;
+
+    Offset? triangleStart;
+    Offset? triangleTip;
 
     if (addTriangleToEdge) {
-      var clippedLine = <double>[];
       final size = bendPoints.length;
+      late final List<double> clippedLine;
       if (nodeData[source]!.isReversed) {
         clippedLine = clipLineEnd(
           bendPoints[2],
@@ -137,74 +185,88 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
           destination.height,
         );
       }
-      final triangleCentroid = drawTriangle(
-        canvas,
-        trianglePaint,
-        clippedLine[0],
-        clippedLine[1],
-        clippedLine[2],
-        clippedLine[3],
-      );
-      path.lineTo(triangleCentroid.dx, triangleCentroid.dy);
+
+      triangleStart = Offset(clippedLine[0], clippedLine[1]);
+      triangleTip = Offset(clippedLine[2], clippedLine[3]);
+      final centroid = _computeTriangleGeometry(
+        triangleStart.dx,
+        triangleStart.dy,
+        triangleTip.dx,
+        triangleTip.dy,
+      ).centroid;
+      path.lineTo(centroid.dx, centroid.dy);
     } else {
       path.lineTo(stopX, stopY);
     }
-    canvas.drawPath(path, currentPaint);
-    paintLabelOnPath(canvas, edge, path);
-  }
 
-  void _renderStraightEdge(
-    Canvas canvas,
-    Edge edge,
-    Paint currentPaint,
-    Paint trianglePaint,
-  ) {
-    final source = edge.source;
-    final destination = edge.destination;
-    final sourceCenter = _getNodeCenter(source);
-    var destCenter = _getNodeCenter(destination);
-
-    if (addTriangleToEdge) {
-      final clippedLine = clipLineEnd(
-        sourceCenter.dx,
-        sourceCenter.dy,
-        destCenter.dx,
-        destCenter.dy,
-        destination.x,
-        destination.y,
-        destination.width,
-        destination.height,
-      );
-
-      destCenter = drawTriangle(
-        canvas,
-        trianglePaint,
-        clippedLine[0],
-        clippedLine[1],
-        clippedLine[2],
-        clippedLine[3],
-      );
-    }
-
-    // Draw the line with appropriate line type using the base class method
-    final lineType = nodeData[destination]?.lineType;
-    drawStyledLine(
-      canvas,
-      sourceCenter,
-      destCenter,
-      currentPaint,
-      lineType: lineType,
+    return _BendPathResult(
+      path,
+      triangleStart: triangleStart,
+      triangleTip: triangleTip,
     );
-    paintLabelOnLine(canvas, edge, sourceCenter, destCenter);
   }
 
-  void _drawSharpBendPointsEdge(List<Offset> bendPoints) {
+  _LineGeometry _computeStraightEdgeGeometry(Edge edge) {
+    final sourceCenter = _getNodeCenter(edge.source);
+    final destinationCenter = _getNodeCenter(edge.destination);
+
+    if (!addTriangleToEdge) {
+      return _LineGeometry(
+        start: sourceCenter,
+        end: destinationCenter,
+      );
+    }
+
+    final clippedLine = clipLineEnd(
+      sourceCenter.dx,
+      sourceCenter.dy,
+      destinationCenter.dx,
+      destinationCenter.dy,
+      edge.destination.x,
+      edge.destination.y,
+      edge.destination.width,
+      edge.destination.height,
+    );
+
+    final triangleStart = Offset(clippedLine[0], clippedLine[1]);
+    final triangleTip = Offset(clippedLine[2], clippedLine[3]);
+    final centroid = _computeTriangleGeometry(
+      triangleStart.dx,
+      triangleStart.dy,
+      triangleTip.dx,
+      triangleTip.dy,
+    ).centroid;
+
+    return _LineGeometry(
+      start: sourceCenter,
+      end: centroid,
+      triangleStart: triangleStart,
+      triangleTip: triangleTip,
+    );
+  }
+
+  @override
+  Offset? getLabelPosition(Edge edge) {
+    if (hasBendEdges(edge)) {
+      final result = _buildBendPath(edge);
+      return resolveLabelPosition(edge, path: result.path);
+    }
+
+    final geometry = _computeStraightEdgeGeometry(edge);
+    return resolveLabelPosition(
+      edge,
+      start: geometry.start,
+      end: geometry.end,
+    );
+  }
+
+  void _drawSharpBendPointsEdge(Path target, List<Offset> bendPoints) {
     for (var i = 1; i < bendPoints.length - 1; i++) {
-      path.lineTo(bendPoints[i].dx, bendPoints[i].dy);
+      target.lineTo(bendPoints[i].dx, bendPoints[i].dy);
     }
   }
 
-  void _drawMaxCurvedBendPointsEdge(List<Offset> bendPoints) {
+  void _drawMaxCurvedBendPointsEdge(Path target, List<Offset> bendPoints) {
     for (var i = 1; i < bendPoints.length - 1; i++) {
       final nextNode = bendPoints[i];
       final afterNextNode = bendPoints[i + 1];
@@ -212,7 +274,7 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
         (nextNode.dx + afterNextNode.dx) / 2,
         (nextNode.dy + afterNextNode.dy) / 2,
       );
-      path.quadraticBezierTo(
+      target.quadraticBezierTo(
         nextNode.dx,
         nextNode.dy,
         curveEndPoint.dx,
@@ -221,7 +283,11 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
     }
   }
 
-  void _drawCurvedBendPointsEdge(List<Offset> bendPoints, double curveLength) {
+  void _drawCurvedBendPointsEdge(
+    Path target,
+    List<Offset> bendPoints,
+    double curveLength,
+  ) {
     for (var i = 1; i < bendPoints.length - 1; i++) {
       final previousNode = i == 1 ? null : bendPoints[i - 2];
       final currentNode = bendPoints[i - 1];
@@ -245,10 +311,10 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
           ((currentNode.dx == nextNode.dx && nextNode.dx == afterNextNode.dx) ||
               (currentNode.dy == nextNode.dy &&
                   nextNode.dy == afterNextNode.dy))) {
-        path.lineTo(nextNode.dx, nextNode.dy);
+        target.lineTo(nextNode.dx, nextNode.dy);
       } else {
-        path.lineTo(arcStartPoint.dx, arcStartPoint.dy);
-        path.quadraticBezierTo(
+        target.lineTo(arcStartPoint.dx, arcStartPoint.dy);
+        target.quadraticBezierTo(
           nextNode.dx,
           nextNode.dy,
           arcEndPoint.dx,
@@ -257,4 +323,16 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
       }
     }
   }
+}
+
+class _BendPathResult {
+  final Path path;
+  final Offset? triangleStart;
+  final Offset? triangleTip;
+
+  _BendPathResult(
+    this.path, {
+    this.triangleStart,
+    this.triangleTip,
+  });
 }

--- a/lib/tree/TreeEdgeRenderer.dart
+++ b/lib/tree/TreeEdgeRenderer.dart
@@ -5,8 +5,6 @@ class TreeEdgeRenderer extends EdgeRenderer {
 
   TreeEdgeRenderer(this.configuration);
 
-  var linePath = Path();
-
   void render(Canvas canvas, Graph graph, Paint paint) {
     graph.edges.forEach((edge) {
       renderEdge(canvas, edge, paint);
@@ -23,21 +21,19 @@ class TreeEdgeRenderer extends EdgeRenderer {
     final childPos = getNodePosition(child);
 
     final orientation = getEffectiveOrientation(node, child);
-
-    linePath.reset();
-    buildEdgePath(node, child, parentPos, childPos, orientation);
+    final path = _buildEdgePath(node, child, parentPos, childPos, orientation);
 
     // Check if the destination node has a specific line type
     final lineType = child.lineType;
 
     if (lineType != LineType.Default) {
       // For styled lines, we need to draw path segments with the appropriate style
-      _drawStyledPath(canvas, linePath, edgePaint, lineType);
+      _drawStyledPath(canvas, path, edgePaint, lineType);
     } else {
-      canvas.drawPath(linePath, edgePaint);
+      canvas.drawPath(path, edgePaint);
     }
 
-    paintLabelOnPath(canvas, edge, linePath);
+    paintLabelOnPath(canvas, edge, path);
   }
 
   /// Draws a path with the specified line type by converting it to line segments
@@ -97,23 +93,27 @@ class TreeEdgeRenderer extends EdgeRenderer {
   }
 
   /// Builds the path for the edge based on orientation
-  void buildEdgePath(
+  Path _buildEdgePath(
     Node node,
     Node child,
     Offset parentPos,
     Offset childPos,
     int orientation,
   ) {
+    final path = Path();
     final parentCenterX = parentPos.dx + node.width * 0.5;
     final parentCenterY = parentPos.dy + node.height * 0.5;
     final childCenterX = childPos.dx + child.width * 0.5;
     final childCenterY = childPos.dy + child.height * 0.5;
 
-    if (parentCenterY == childCenterY && parentCenterX == childCenterX) return;
+    if (parentCenterY == childCenterY && parentCenterX == childCenterX) {
+      return path;
+    }
 
     switch (orientation) {
       case BuchheimWalkerConfiguration.ORIENTATION_TOP_BOTTOM:
         buildTopBottomPath(
+          path,
           node,
           child,
           parentPos,
@@ -127,6 +127,7 @@ class TreeEdgeRenderer extends EdgeRenderer {
 
       case BuchheimWalkerConfiguration.ORIENTATION_BOTTOM_TOP:
         buildBottomTopPath(
+          path,
           node,
           child,
           parentPos,
@@ -140,6 +141,7 @@ class TreeEdgeRenderer extends EdgeRenderer {
 
       case BuchheimWalkerConfiguration.ORIENTATION_LEFT_RIGHT:
         buildLeftRightPath(
+          path,
           node,
           child,
           parentPos,
@@ -153,6 +155,7 @@ class TreeEdgeRenderer extends EdgeRenderer {
 
       case BuchheimWalkerConfiguration.ORIENTATION_RIGHT_LEFT:
         buildRightLeftPath(
+          path,
           node,
           child,
           parentPos,
@@ -164,10 +167,13 @@ class TreeEdgeRenderer extends EdgeRenderer {
         );
         break;
     }
+
+    return path;
   }
 
   /// Builds path for top-bottom orientation
   void buildTopBottomPath(
+    Path path,
     Node node,
     Node child,
     Offset parentPos,
@@ -183,7 +189,7 @@ class TreeEdgeRenderer extends EdgeRenderer {
 
     if (configuration.useCurvedConnections) {
       // Curved connection
-      linePath
+      path
         ..moveTo(childCenterX, childTopY)
         ..cubicTo(
           childCenterX,
@@ -195,7 +201,7 @@ class TreeEdgeRenderer extends EdgeRenderer {
         );
     } else {
       // L-shaped connection
-      linePath
+      path
         ..moveTo(parentCenterX, parentBottomY)
         ..lineTo(parentCenterX, midY)
         ..lineTo(childCenterX, midY)
@@ -205,6 +211,7 @@ class TreeEdgeRenderer extends EdgeRenderer {
 
   /// Builds path for bottom-top orientation
   void buildBottomTopPath(
+    Path path,
     Node node,
     Node child,
     Offset parentPos,
@@ -219,7 +226,7 @@ class TreeEdgeRenderer extends EdgeRenderer {
     final midY = (parentTopY + childBottomY) * 0.5;
 
     if (configuration.useCurvedConnections) {
-      linePath
+      path
         ..moveTo(childCenterX, childBottomY)
         ..cubicTo(
           childCenterX,
@@ -230,7 +237,7 @@ class TreeEdgeRenderer extends EdgeRenderer {
           parentTopY,
         );
     } else {
-      linePath
+      path
         ..moveTo(parentCenterX, parentTopY)
         ..lineTo(parentCenterX, midY)
         ..lineTo(childCenterX, midY)
@@ -240,6 +247,7 @@ class TreeEdgeRenderer extends EdgeRenderer {
 
   /// Builds path for left-right orientation
   void buildLeftRightPath(
+    Path path,
     Node node,
     Node child,
     Offset parentPos,
@@ -254,7 +262,7 @@ class TreeEdgeRenderer extends EdgeRenderer {
     final midX = (parentRightX + childLeftX) * 0.5;
 
     if (configuration.useCurvedConnections) {
-      linePath
+      path
         ..moveTo(childLeftX, childCenterY)
         ..cubicTo(
           midX,
@@ -265,7 +273,7 @@ class TreeEdgeRenderer extends EdgeRenderer {
           parentCenterY,
         );
     } else {
-      linePath
+      path
         ..moveTo(parentRightX, parentCenterY)
         ..lineTo(midX, parentCenterY)
         ..lineTo(midX, childCenterY)
@@ -275,6 +283,7 @@ class TreeEdgeRenderer extends EdgeRenderer {
 
   /// Builds path for right-left orientation
   void buildRightLeftPath(
+    Path path,
     Node node,
     Node child,
     Offset parentPos,
@@ -289,7 +298,7 @@ class TreeEdgeRenderer extends EdgeRenderer {
     final midX = (parentLeftX + childRightX) * 0.5;
 
     if (configuration.useCurvedConnections) {
-      linePath
+      path
         ..moveTo(childRightX, childCenterY)
         ..cubicTo(
           midX,
@@ -300,11 +309,22 @@ class TreeEdgeRenderer extends EdgeRenderer {
           parentCenterY,
         );
     } else {
-      linePath
+      path
         ..moveTo(parentLeftX, parentCenterY)
         ..lineTo(midX, parentCenterY)
         ..lineTo(midX, childCenterY)
         ..lineTo(childRightX, childCenterY);
     }
+  }
+
+  @override
+  Offset? getLabelPosition(Edge edge) {
+    final node = edge.source;
+    final child = edge.destination;
+    final parentPos = getNodePosition(node);
+    final childPos = getNodePosition(child);
+    final orientation = getEffectiveOrientation(node, child);
+    final path = _buildEdgePath(node, child, parentPos, childPos, orientation);
+    return resolveLabelPosition(edge, path: path);
   }
 }


### PR DESCRIPTION
## Summary
- add builder-aware label resolution in `EdgeRenderer` and expose `getLabelPosition`
- refactor arrow, tree, and sugiyama edge renderers to return label geometry
- let `RenderCustomLayoutBox` place edge label widgets via renderer-provided positions

## Testing
- Not run (Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1c5768400832ea93e71671409f694