### PR TITLE
Refine self-loop rendering with elliptical arcs

### DIFF
--- a/lib/edgerenderer/EdgeRenderer.dart
+++ b/lib/edgerenderer/EdgeRenderer.dart
@@ -156,33 +156,36 @@ abstract class EdgeRenderer {
       nodePosition.dy + node.height * 0.5,
     );
 
+    final horizontalRadius = node.width * 0.5 + loopPadding;
+    final verticalRadius = node.height * 0.5 + loopPadding;
+
+    final ellipseCenter = Offset(
+      start.dx - horizontalRadius,
+      start.dy,
+    );
+
+    const startAngle = 0.0;
+    const sweepAngle = -pi / 2;
+    final endAngle = startAngle + sweepAngle;
+
+    final ellipseRect = Rect.fromCenter(
+      center: ellipseCenter,
+      width: horizontalRadius * 2,
+      height: verticalRadius * 2,
+    );
+
     final end = Offset(
-      nodePosition.dx + node.width * 0.5,
-      nodePosition.dy,
-    );
-
-    final horizontalOffset = max(loopPadding + node.width * 0.4, 24.0);
-    final verticalOffset = max(loopPadding + node.height * 0.8, 32.0);
-
-    final controlPoint1 = Offset(
-      start.dx + horizontalOffset,
-      start.dy - verticalOffset,
-    );
-
-    final controlPoint2 = Offset(
-      end.dx + horizontalOffset * 0.6,
-      end.dy - verticalOffset,
+      ellipseCenter.dx + horizontalRadius * cos(endAngle),
+      ellipseCenter.dy + verticalRadius * sin(endAngle),
     );
 
     final path = Path()
       ..moveTo(start.dx, start.dy)
-      ..cubicTo(
-        controlPoint1.dx,
-        controlPoint1.dy,
-        controlPoint2.dx,
-        controlPoint2.dy,
-        end.dx,
-        end.dy,
+      ..arcTo(
+        ellipseRect,
+        startAngle,
+        sweepAngle,
+        false,
       );
 
     final metrics = path.computeMetrics().toList();

--- a/test/graph_test.dart
+++ b/test/graph_test.dart
@@ -94,14 +94,53 @@ void main() {
         ..position = const Offset(100, 100);
 
       final edge = Edge(node, node);
-      final result = renderer.buildSelfLoopPath(edge);
+      final result = renderer.buildSelfLoopPath(edge, arrowLength: 0);
 
       expect(result, isNotNull);
 
       final metrics = result!.path.computeMetrics().toList();
       expect(metrics, isNotEmpty);
       expect(metrics.first.length, greaterThan(0));
-      expect(result.arrowTip, isNot(equals(const Offset(0, 0))));
+
+      final loopPadding = 16.0;
+      final horizontalRadius = node.width * 0.5 + loopPadding;
+      final verticalRadius = node.height * 0.5 + loopPadding;
+
+      final start = Offset(
+        node.position.dx + node.width,
+        node.position.dy + node.height * 0.5,
+      );
+
+      final ellipseCenter = Offset(
+        start.dx - horizontalRadius,
+        start.dy,
+      );
+
+      final expectedBounds = Rect.fromLTRB(
+        ellipseCenter.dx,
+        ellipseCenter.dy - verticalRadius,
+        start.dx,
+        start.dy,
+      );
+
+      final bounds = result.path.getBounds();
+      expect(bounds.left, closeTo(expectedBounds.left, 0.01));
+      expect(bounds.top, closeTo(expectedBounds.top, 0.01));
+      expect(bounds.right, closeTo(expectedBounds.right, 0.01));
+      expect(bounds.bottom, closeTo(expectedBounds.bottom, 0.01));
+
+      final metric = metrics.first;
+      final tangent = metric.getTangentForOffset(metric.length);
+      expect(tangent, isNotNull);
+      expect(tangent!.vector.dx, lessThan(0));
+      expect(tangent.vector.dy, closeTo(0, 1e-3));
+
+      final expectedEnd = Offset(
+        ellipseCenter.dx,
+        ellipseCenter.dy - verticalRadius,
+      );
+      expect(result.arrowTip.dx, closeTo(expectedEnd.dx, 0.01));
+      expect(result.arrowTip.dy, closeTo(expectedEnd.dy, 0.01));
     });
 
     test('SugiyamaAlgorithm handles single node self loop', () {


### PR DESCRIPTION
## Summary
- replace the cubic Bezier self-loop path with an elliptical arc that scales with node dimensions and loop padding
- preserve path trimming while calculating arc geometry for arrow placement
- update the self-loop renderer test to validate the arc bounds, tangent, and endpoint

## Testing
- Not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e39602b678832e8993ca53854c5d63