### PR TITLE
Refine self-loop rendering with elliptical arcs

### DIFF
--- a/lib/edgerenderer/EdgeRenderer.dart
+++ b/lib/edgerenderer/EdgeRenderer.dart
@@ -161,29 +161,26 @@ abstract class EdgeRenderer {
       nodePosition.dy,
     );
 
-    final horizontalOffset = max(loopPadding + node.width * 0.4, 24.0);
-    final verticalOffset = max(loopPadding + node.height * 0.8, 32.0);
-
-    final controlPoint1 = Offset(
-      start.dx + horizontalOffset,
-      start.dy - verticalOffset,
+    final nodeCenter = Offset(
+      nodePosition.dx + node.width * 0.5,
+      nodePosition.dy + node.height * 0.5,
     );
 
-    final controlPoint2 = Offset(
-      end.dx + horizontalOffset * 0.6,
-      end.dy - verticalOffset,
+    final horizontalRadius = node.width * 0.5 + loopPadding;
+    final verticalRadius = node.height * 0.5 + loopPadding;
+
+    final arcStart = Offset(nodeCenter.dx + horizontalRadius, nodeCenter.dy);
+    final arcRect = Rect.fromCenter(
+      center: nodeCenter,
+      width: horizontalRadius * 2,
+      height: verticalRadius * 2,
     );
 
     final path = Path()
       ..moveTo(start.dx, start.dy)
-      ..cubicTo(
-        controlPoint1.dx,
-        controlPoint1.dy,
-        controlPoint2.dx,
-        controlPoint2.dy,
-        end.dx,
-        end.dy,
-      );
+      ..lineTo(arcStart.dx, arcStart.dy)
+      ..addArc(arcRect, 0.0, -pi / 2)
+      ..lineTo(end.dx, end.dy);
 
     final metrics = path.computeMetrics().toList();
     if (metrics.isEmpty) {

--- a/test/graph_test.dart
+++ b/test/graph_test.dart
@@ -88,20 +88,46 @@ void main() {
     });
 
     test('ArrowEdgeRenderer builds self-loop path', () {
+      const loopPadding = 16.0;
       final renderer = ArrowEdgeRenderer();
       final node = Node.Id('self')
         ..size = const Size(40, 40)
         ..position = const Offset(100, 100);
 
       final edge = Edge(node, node);
-      final result = renderer.buildSelfLoopPath(edge);
+      final result = renderer.buildSelfLoopPath(
+        edge,
+        loopPadding: loopPadding,
+        arrowLength: 0,
+      );
 
       expect(result, isNotNull);
 
-      final metrics = result!.path.computeMetrics().toList();
+      final path = result!.path;
+      final metrics = path.computeMetrics().toList();
       expect(metrics, isNotEmpty);
       expect(metrics.first.length, greaterThan(0));
-      expect(result.arrowTip, isNot(equals(const Offset(0, 0))));
+
+      final nodeCenter = Offset(
+        node.position.dx + node.width * 0.5,
+        node.position.dy + node.height * 0.5,
+      );
+      final horizontalRadius = node.width * 0.5 + loopPadding;
+      final verticalRadius = node.height * 0.5 + loopPadding;
+      final expectedArcStart = Offset(nodeCenter.dx + horizontalRadius, nodeCenter.dy);
+      final expectedArcTop = Offset(nodeCenter.dx, nodeCenter.dy - verticalRadius);
+
+      final bounds = path.getBounds();
+      expect(bounds.right, closeTo(expectedArcStart.dx, 1e-6));
+      expect(bounds.top, closeTo(expectedArcTop.dy, 1e-6));
+      expect(bounds.left, closeTo(expectedArcTop.dx, 1e-6));
+      expect(bounds.bottom, closeTo(node.position.dy + node.height * 0.5, 1e-6));
+
+      final tangent = metrics.first.getTangentForOffset(metrics.first.length);
+      expect(tangent, isNotNull);
+      expect(tangent!.vector.dx, closeTo(0, 1e-6));
+      expect(tangent.vector.dy, greaterThan(0));
+      expect(result.arrowTip, equals(Offset(nodeCenter.dx, node.position.dy)));
     });
 
     test('SugiyamaAlgorithm handles single node self loop', () {


### PR DESCRIPTION
## Summary
- render self-loop edges using an elliptical arc that scales with node dimensions
- keep arrow trimming while basing loop geometry on radii derived from node size and padding
- extend the self-loop renderer test to validate arc bounds and tangent orientation

## Testing
- `flutter test` *(fails: flutter command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3960a14e0832ea2fd37d0bac1fad5