### PR TITLE
Adjust self-loop control points for smooth tangents

### DIFF
--- a/lib/edgerenderer/EdgeRenderer.dart
+++ b/lib/edgerenderer/EdgeRenderer.dart
@@ -152,18 +152,21 @@ abstract class EdgeRenderer {
     final nodePosition = getNodePosition(node);
 
     final start = Offset(
-      nodePosition.dx + node.width,
-      nodePosition.dy + node.height * 0.5,
-    );
-
-    final end = Offset(
       nodePosition.dx + node.width * 0.5,
       nodePosition.dy,
     );
 
-    final loopRadius = max(loopPadding, node.size.shortestSide * 0.5);
+    final end = Offset(
+      nodePosition.dx,
+      nodePosition.dy + node.height * 0.5,
+    );
 
-    final controlPoint1 = start + Offset(loopRadius, 0);
+    final loopRadius = max(
+      loopPadding + node.size.shortestSide * 0.25,
+      node.size.shortestSide * 0.75,
+    );
+
+    final controlPoint1 = start + Offset(0, -loopRadius);
 
     final controlPoint2 = end + Offset(0, -loopRadius);
 

--- a/lib/edgerenderer/EdgeRenderer.dart
+++ b/lib/edgerenderer/EdgeRenderer.dart
@@ -153,16 +153,16 @@ abstract class EdgeRenderer {
 
     final anchorRadius = node.size.shortestSide * 0.5;
 
-    final start = nodeCenter + Offset(0, -anchorRadius);
+    final start = nodeCenter + Offset(anchorRadius, 0);
 
-    final end = nodeCenter + Offset(-anchorRadius, 0);
+    final end = nodeCenter + Offset(0, -anchorRadius);
 
     final loopRadius = max(
       loopPadding + anchorRadius,
       anchorRadius * 1.5,
     );
 
-    final controlPoint1 = start + Offset(-loopRadius, 0);
+    final controlPoint1 = start + Offset(loopRadius, 0);
 
     final controlPoint2 = end + Offset(0, -loopRadius);
 

--- a/lib/edgerenderer/EdgeRenderer.dart
+++ b/lib/edgerenderer/EdgeRenderer.dart
@@ -149,24 +149,20 @@ abstract class EdgeRenderer {
     }
 
     final node = edge.source;
-    final nodePosition = getNodePosition(node);
+    final nodeCenter = getNodeCenter(node);
 
-    final start = Offset(
-      nodePosition.dx + node.width * 0.5,
-      nodePosition.dy,
-    );
+    final anchorRadius = node.size.shortestSide * 0.5;
 
-    final end = Offset(
-      nodePosition.dx,
-      nodePosition.dy + node.height * 0.5,
-    );
+    final start = nodeCenter + Offset(0, -anchorRadius);
+
+    final end = nodeCenter + Offset(-anchorRadius, 0);
 
     final loopRadius = max(
-      loopPadding + node.size.shortestSide * 0.25,
-      node.size.shortestSide * 0.75,
+      loopPadding + anchorRadius,
+      anchorRadius * 1.5,
     );
 
-    final controlPoint1 = start + Offset(0, -loopRadius);
+    final controlPoint1 = start + Offset(-loopRadius, 0);
 
     final controlPoint2 = end + Offset(0, -loopRadius);
 

--- a/lib/edgerenderer/EdgeRenderer.dart
+++ b/lib/edgerenderer/EdgeRenderer.dart
@@ -161,18 +161,11 @@ abstract class EdgeRenderer {
       nodePosition.dy,
     );
 
-    final horizontalOffset = max(loopPadding + node.width * 0.4, 24.0);
-    final verticalOffset = max(loopPadding + node.height * 0.8, 32.0);
+    final loopRadius = max(loopPadding, node.size.shortestSide * 0.5);
 
-    final controlPoint1 = Offset(
-      start.dx + horizontalOffset,
-      start.dy - verticalOffset,
-    );
+    final controlPoint1 = start + Offset(loopRadius, 0);
 
-    final controlPoint2 = Offset(
-      end.dx + horizontalOffset * 0.6,
-      end.dy - verticalOffset,
-    );
+    final controlPoint2 = end + Offset(0, -loopRadius);
 
     final path = Path()
       ..moveTo(start.dx, start.dy)

--- a/test/graph_test.dart
+++ b/test/graph_test.dart
@@ -108,7 +108,7 @@ void main() {
       expect(tangentStart, isNotNull);
       expect(tangentStart!.vector.dy.abs(),
           lessThan(tangentStart.vector.dx.abs() * 0.1));
-      expect(tangentStart.vector.dx, lessThan(0));
+      expect(tangentStart.vector.dx, greaterThan(0));
 
       final tangentEnd = metric.getTangentForOffset(metric.length);
       expect(tangentEnd, isNotNull);

--- a/test/graph_test.dart
+++ b/test/graph_test.dart
@@ -106,9 +106,9 @@ void main() {
 
       final tangentStart = metric.getTangentForOffset(0);
       expect(tangentStart, isNotNull);
-      expect(tangentStart!.vector.dx.abs(),
-          lessThan(tangentStart.vector.dy.abs() * 0.1));
-      expect(tangentStart.vector.dy, lessThan(0));
+      expect(tangentStart!.vector.dy.abs(),
+          lessThan(tangentStart.vector.dx.abs() * 0.1));
+      expect(tangentStart.vector.dx, lessThan(0));
 
       final tangentEnd = metric.getTangentForOffset(metric.length);
       expect(tangentEnd, isNotNull);

--- a/test/graph_test.dart
+++ b/test/graph_test.dart
@@ -106,13 +106,15 @@ void main() {
 
       final tangentStart = metric.getTangentForOffset(0);
       expect(tangentStart, isNotNull);
-      expect(tangentStart!.vector.dy.abs(),
-          lessThan(tangentStart.vector.dx.abs() * 0.1));
+      expect(tangentStart!.vector.dx.abs(),
+          lessThan(tangentStart.vector.dy.abs() * 0.1));
+      expect(tangentStart.vector.dy, lessThan(0));
 
       final tangentEnd = metric.getTangentForOffset(metric.length);
       expect(tangentEnd, isNotNull);
       expect(tangentEnd!.vector.dx.abs(),
           lessThan(tangentEnd.vector.dy.abs() * 0.1));
+      expect(tangentEnd.vector.dy, greaterThan(0));
     });
 
     test('SugiyamaAlgorithm handles single node self loop', () {

--- a/test/graph_test.dart
+++ b/test/graph_test.dart
@@ -100,8 +100,19 @@ void main() {
 
       final metrics = result!.path.computeMetrics().toList();
       expect(metrics, isNotEmpty);
-      expect(metrics.first.length, greaterThan(0));
+      final metric = metrics.first;
+      expect(metric.length, greaterThan(0));
       expect(result.arrowTip, isNot(equals(const Offset(0, 0))));
+
+      final tangentStart = metric.getTangentForOffset(0);
+      expect(tangentStart, isNotNull);
+      expect(tangentStart!.vector.dy.abs(),
+          lessThan(tangentStart.vector.dx.abs() * 0.1));
+
+      final tangentEnd = metric.getTangentForOffset(metric.length);
+      expect(tangentEnd, isNotNull);
+      expect(tangentEnd!.vector.dx.abs(),
+          lessThan(tangentEnd.vector.dy.abs() * 0.1));
     });
 
     test('SugiyamaAlgorithm handles single node self loop', () {


### PR DESCRIPTION
## Summary
- compute a loop radius for self-loop edges and align control points to ensure horizontal/vertical tangents
- extend the self-loop renderer test to validate the new tangent behavior

## Testing
- not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3960eaf3c832e8e5e40a0b71f3732