### PR TITLE
Add configurable self-loop styling

### DIFF
--- a/example/lib/loop_styles_graphview.dart
+++ b/example/lib/loop_styles_graphview.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:graphview/GraphView.dart';
+
+class LoopStylesGraphViewPage extends StatefulWidget {
+  const LoopStylesGraphViewPage({super.key});
+
+  @override
+  State<LoopStylesGraphViewPage> createState() => _LoopStylesGraphViewPageState();
+}
+
+class _LoopStylesGraphViewPageState extends State<LoopStylesGraphViewPage> {
+  final Graph _graph = Graph()..isTree = false;
+  late final SugiyamaConfiguration _configuration;
+  late final SugiyamaAlgorithm _algorithm;
+
+  @override
+  void initState() {
+    super.initState();
+    _configuration = SugiyamaConfiguration()
+      ..nodeSeparation = 80
+      ..levelSeparation = 120
+      ..orientation = SugiyamaConfiguration.ORIENTATION_TOP_BOTTOM;
+    _algorithm = SugiyamaAlgorithm(_configuration);
+    _buildGraph();
+  }
+
+  void _buildGraph() {
+    final center = Node.Id('Center');
+    final top = Node.Id('Top loop');
+    final right = Node.Id('Right loop');
+    final bottom = Node.Id('Bottom loop');
+    final left = Node.Id('Left loop');
+
+    _graph.addNode(center);
+    _graph.addNode(top);
+    _graph.addNode(right);
+    _graph.addNode(bottom);
+    _graph.addNode(left);
+
+    _graph.addEdge(center, top);
+    _graph.addEdge(center, right);
+    _graph.addEdge(center, bottom);
+    _graph.addEdge(center, left);
+
+    _graph.addEdge(
+      top,
+      top,
+      loopStyle: const LoopEdgeStyle(
+        orientation: LoopOrientation.topRight,
+        radius: 48,
+        tension: 0.7,
+      ),
+      paint: Paint()
+        ..color = Colors.deepPurple
+        ..strokeWidth = 2.4,
+    );
+
+    _graph.addEdge(
+      right,
+      right,
+      loopStyle: const LoopEdgeStyle(
+        orientation: LoopOrientation.bottomRight,
+        radius: 56,
+        tension: 0.55,
+        offset: Offset(24, 0),
+      ),
+      paint: Paint()
+        ..color = Colors.teal
+        ..strokeWidth = 2.4,
+    );
+
+    _graph.addEdge(
+      bottom,
+      bottom,
+      loopStyle: const LoopEdgeStyle(
+        orientation: LoopOrientation.bottomLeft,
+        radius: 40,
+        tension: 0.4,
+      ),
+      paint: Paint()
+        ..color = Colors.orange
+        ..strokeWidth = 2.4,
+    );
+
+    _graph.addEdge(
+      left,
+      left,
+      loopStyle: const LoopEdgeStyle(
+        orientation: LoopOrientation.topLeft,
+        radius: 64,
+        tension: 0.8,
+        offset: Offset(-16, -12),
+      ),
+      paint: Paint()
+        ..color = Colors.indigo
+        ..strokeWidth = 2.4,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Loop edge styles'),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Text(
+              'Self loops now support orientation, radius, tension and offset. '
+              'Adjust the style to create compact, circular or elongated loops.',
+              style: Theme.of(context).textTheme.bodyLarge,
+              textAlign: TextAlign.center,
+            ),
+          ),
+          Expanded(
+            child: InteractiveViewer(
+              constrained: false,
+              boundaryMargin: const EdgeInsets.all(64),
+              minScale: 0.2,
+              maxScale: 4,
+              child: GraphView(
+                graph: _graph,
+                algorithm: _algorithm,
+                paint: Paint()
+                  ..color = Colors.black
+                  ..strokeWidth = 2
+                  ..style = PaintingStyle.stroke,
+                builder: (Node node) {
+                  return _buildNodeWidget(node.key?.value);
+                },
+                edgePaintBuilder: (edge) => (edge.paint ?? Paint())
+                  ..style = PaintingStyle.stroke,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNodeWidget(dynamic label) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: const [
+          BoxShadow(
+            color: Colors.black12,
+            blurRadius: 8,
+            offset: Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Text(
+        '$label',
+        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,6 +12,7 @@ import 'force_directed_graphview.dart';
 import 'graph_cluster_animated.dart';
 import 'layer_eiglesperger_graphview.dart';
 import 'layer_graphview_json.dart';
+import 'loop_styles_graphview.dart';
 import 'tree_graphview.dart';
 
 void main() {
@@ -167,6 +168,13 @@ class Home extends StatelessWidget {
               Icons.layers,
               Colors.teal,
                   () => LayeredEiglspergerGraphViewPage(),
+            ),
+            _buildButton(
+              'Loop Styles',
+              'Self-loop styling options',
+              Icons.loop,
+              Colors.amber,
+              () => const LoopStylesGraphViewPage(),
             ),
           ]),
         ],

--- a/lib/Graph.dart
+++ b/lib/Graph.dart
@@ -42,8 +42,9 @@ class Graph {
 
   void removeNodes(List<Node> nodes) => nodes.forEach((it) => removeNode(it));
 
-  Edge addEdge(Node source, Node destination, {Paint? paint}) {
-    final edge = Edge(source, destination, paint: paint);
+  Edge addEdge(Node source, Node destination,
+      {Paint? paint, LoopEdgeStyle? loopStyle}) {
+    final edge = Edge(source, destination, paint: paint, loopStyle: loopStyle);
     addEdgeS(edge);
     return edge;
   }
@@ -276,6 +277,27 @@ class Node {
   }
 }
 
+enum LoopOrientation {
+  topRight,
+  topLeft,
+  bottomLeft,
+  bottomRight,
+}
+
+class LoopEdgeStyle {
+  final LoopOrientation orientation;
+  final double radius;
+  final double tension;
+  final Offset offset;
+
+  const LoopEdgeStyle({
+    this.orientation = LoopOrientation.topRight,
+    this.radius = 32.0,
+    this.tension = 0.6,
+    this.offset = Offset.zero,
+  });
+}
+
 class Edge {
   Node source;
   Node destination;
@@ -283,7 +305,10 @@ class Edge {
   Key? key;
   Paint? paint;
 
-  Edge(this.source, this.destination, {this.key, this.paint});
+  LoopEdgeStyle? loopStyle;
+
+  Edge(this.source, this.destination,
+      {this.key, this.paint, this.loopStyle});
 
   @override
   bool operator ==(Object? other) =>

--- a/lib/edgerenderer/ArrowEdgeRenderer.dart
+++ b/lib/edgerenderer/ArrowEdgeRenderer.dart
@@ -34,6 +34,7 @@ class ArrowEdgeRenderer extends EdgeRenderer {
     if (source == destination) {
       final loopResult = buildSelfLoopPath(
         edge,
+        style: edge.loopStyle,
         arrowLength: noArrow ? 0.0 : ARROW_LENGTH,
       );
 

--- a/lib/edgerenderer/EdgeRenderer.dart
+++ b/lib/edgerenderer/EdgeRenderer.dart
@@ -141,7 +141,7 @@ abstract class EdgeRenderer {
   /// data that renderers can use to draw arrows or style the segment.
   LoopRenderResult? buildSelfLoopPath(
     Edge edge, {
-    double loopPadding = 16.0,
+    LoopEdgeStyle? style,
     double arrowLength = 12.0,
   }) {
     if (edge.source != edge.destination) {
@@ -150,29 +150,52 @@ abstract class EdgeRenderer {
 
     final node = edge.source;
     final nodePosition = getNodePosition(node);
-
-    final start = Offset(
-      nodePosition.dx + node.width,
+    final loopStyle = style ?? edge.loopStyle ?? const LoopEdgeStyle();
+    final nodeCenter = Offset(
+      nodePosition.dx + node.width * 0.5,
       nodePosition.dy + node.height * 0.5,
     );
 
-    final end = Offset(
-      nodePosition.dx + node.width * 0.5,
-      nodePosition.dy,
-    );
+    late Offset start;
+    late Offset end;
+    switch (loopStyle.orientation) {
+      case LoopOrientation.topRight:
+        start = Offset(nodePosition.dx + node.width, nodeCenter.dy);
+        end = Offset(nodeCenter.dx, nodePosition.dy);
+        break;
+      case LoopOrientation.topLeft:
+        start = Offset(nodePosition.dx, nodeCenter.dy);
+        end = Offset(nodeCenter.dx, nodePosition.dy);
+        break;
+      case LoopOrientation.bottomLeft:
+        start = Offset(nodePosition.dx, nodeCenter.dy);
+        end = Offset(nodeCenter.dx, nodePosition.dy + node.height);
+        break;
+      case LoopOrientation.bottomRight:
+        start = Offset(nodePosition.dx + node.width, nodeCenter.dy);
+        end = Offset(nodeCenter.dx, nodePosition.dy + node.height);
+        break;
+    }
 
-    final horizontalOffset = max(loopPadding + node.width * 0.4, 24.0);
-    final verticalOffset = max(loopPadding + node.height * 0.8, 32.0);
+    final vector = _loopOrientationVector(loopStyle.orientation);
+    final vectorLength = vector.distance == 0 ? 1.0 : vector.distance;
+    final normalizedVector = Offset(vector.dx / vectorLength, vector.dy / vectorLength);
 
-    final controlPoint1 = Offset(
-      start.dx + horizontalOffset,
-      start.dy - verticalOffset,
-    );
+    final baseRadius = max(0.0, loopStyle.radius);
+    final halfWidth = node.width * 0.5;
+    final halfHeight = node.height * 0.5;
+    final nodeRadius = sqrt(halfWidth * halfWidth + halfHeight * halfHeight);
+    final anchorDistance = nodeRadius + baseRadius;
+    final anchor = nodeCenter +
+        Offset(
+          normalizedVector.dx * anchorDistance,
+          normalizedVector.dy * anchorDistance,
+        ) +
+        loopStyle.offset;
 
-    final controlPoint2 = Offset(
-      end.dx + horizontalOffset * 0.6,
-      end.dy - verticalOffset,
-    );
+    final tension = loopStyle.tension.clamp(0.0, 1.0);
+    final controlPoint1 = Offset.lerp(start, anchor, tension) ?? start;
+    final controlPoint2 = Offset.lerp(end, anchor, tension) ?? end;
 
     final path = Path()
       ..moveTo(start.dx, start.dy)
@@ -208,6 +231,19 @@ abstract class EdgeRenderer {
       arrowBaseTangent?.position ?? end,
       arrowTipTangent?.position ?? end,
     );
+  }
+
+  Offset _loopOrientationVector(LoopOrientation orientation) {
+    switch (orientation) {
+      case LoopOrientation.topRight:
+        return const Offset(1, -1);
+      case LoopOrientation.topLeft:
+        return const Offset(-1, -1);
+      case LoopOrientation.bottomLeft:
+        return const Offset(-1, 1);
+      case LoopOrientation.bottomRight:
+        return const Offset(1, 1);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add a `LoopEdgeStyle` API that can be passed when creating edges
- update the self-loop renderer to honor the loop style and keep arrow trimming
- add a demo screen that showcases several loop style combinations

## Testing
- Not run (dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e393ba6f48832e969333b6dfbbf212