### PR TITLE
Loop edge renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ build/
 !**/ios/**/default.mode2v3
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
+AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.1
+- Fix Zoom To fit for hidden nodes
+- Add Fade in Support for Edges
+
 ## 1.5.0
 
 - **MAJOR UPDATE**: Added 5 new layout algorithms
@@ -18,10 +22,10 @@
     - `animated`: Enable/disable smooth animations (default: true)
     - `autoZoomToFit`: Automatically zoom to fit all nodes on initialization
     - `initialNode`: Jump to specific node on startup
-    - `panAnimationDuration`: Customizable camera movement timing
-    - `centerGraph`: Center the graph within viewport
+    - `panAnimationDuration`: Customizable navigation movement timing
+    - `centerGraph`: Center the graph within viewport having a fixed large size of 2000000
     - `controller`: GraphViewController for programmatic control
-- **NEW**: Navigation and camera control features
+- **NEW**: Navigation and pan control features
     - `jumpToNode()` and `animateToNode()` for programmatic navigation
     - `zoomToFit()` for automatic viewport adjustment
     - `resetView()` for returning to origin

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,7 +73,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.5.0"
+    version: "1.5.1"
   leak_tracker:
     dependency: transitive
     description:

--- a/lib/Graph.dart
+++ b/lib/Graph.dart
@@ -51,20 +51,31 @@ class Graph {
   void addEdgeS(Edge edge) {
     var sourceSet = false;
     var destinationSet = false;
-    _nodes.forEach((node) {
+    for (var node in _nodes) {
       if (!sourceSet && node == edge.source) {
         edge.source = node;
         sourceSet = true;
-      } else if (!destinationSet && node == edge.destination) {
+      }
+
+      if (!destinationSet && node == edge.destination) {
         edge.destination = node;
         destinationSet = true;
       }
-    });
+
+      if (sourceSet && destinationSet) {
+        break;
+      }
+    }
     if (!sourceSet) {
       _nodes.add(edge.source);
+      sourceSet = true;
+      if (!destinationSet && edge.destination == edge.source) {
+        destinationSet = true;
+      }
     }
     if (!destinationSet) {
       _nodes.add(edge.destination);
+      destinationSet = true;
     }
 
     if (!_edges.contains(edge)) {

--- a/lib/GraphView.dart
+++ b/lib/GraphView.dart
@@ -355,9 +355,9 @@ class GraphView extends StatefulWidget {
 
 class _GraphViewState extends State<GraphView> with TickerProviderStateMixin {
   late TransformationController _transformationController;
-  late final AnimationController _cameraController;
+  late final AnimationController _panController;
   late final AnimationController _nodeController;
-  Animation<Matrix4>? _cameraAnimation;
+  Animation<Matrix4>? _panAnimation;
 
   @override
   void initState() {
@@ -366,7 +366,7 @@ class _GraphViewState extends State<GraphView> with TickerProviderStateMixin {
     _transformationController = widget.controller?.transformationController ??
         TransformationController();
 
-    _cameraController = AnimationController(
+    _panController = AnimationController(
       vsync: this,
       duration:
           widget.panAnimationDuration ?? const Duration(milliseconds: 600),
@@ -394,7 +394,7 @@ class _GraphViewState extends State<GraphView> with TickerProviderStateMixin {
   @override
   void dispose() {
     widget.controller?._detach();
-    _cameraController.dispose();
+    _panController.dispose();
     _nodeController.dispose();
     _transformationController.dispose();
     super.dispose();
@@ -489,22 +489,22 @@ class _GraphViewState extends State<GraphView> with TickerProviderStateMixin {
   }
 
   void animateToMatrix(Matrix4 target) {
-    _cameraController.reset();
-    _cameraAnimation = Matrix4Tween(
+    _panController.reset();
+    _panAnimation = Matrix4Tween(
             begin: _transformationController.value, end: target)
         .animate(
-            CurvedAnimation(parent: _cameraController, curve: Curves.linear));
-    _cameraAnimation!.addListener(_onCameraTick);
-    _cameraController.forward();
+            CurvedAnimation(parent: _panController, curve: Curves.linear));
+    _panAnimation!.addListener(_onPanTick);
+    _panController.forward();
   }
 
-  void _onCameraTick() {
-    if (_cameraAnimation == null) return;
-    _transformationController.value = _cameraAnimation!.value;
-    if (!_cameraController.isAnimating) {
-      _cameraAnimation!.removeListener(_onCameraTick);
-      _cameraAnimation = null;
-      _cameraController.reset();
+  void _onPanTick() {
+    if (_panAnimation == null) return;
+    _transformationController.value = _panAnimation!.value;
+    if (!_panController.isAnimating) {
+      _panAnimation!.removeListener(_onPanTick);
+      _panAnimation = null;
+      _panController.reset();
     }
   }
 

--- a/lib/edgerenderer/ArrowEdgeRenderer.dart
+++ b/lib/edgerenderer/ArrowEdgeRenderer.dart
@@ -28,6 +28,44 @@ class ArrowEdgeRenderer extends EdgeRenderer {
     var source = edge.source;
     var destination = edge.destination;
 
+    final currentPaint = (edge.paint ?? paint)..style = PaintingStyle.stroke;
+    final lineType = _getLineType(destination);
+
+    if (source == destination) {
+      final loopResult = buildSelfLoopPath(
+        edge,
+        arrowLength: noArrow ? 0.0 : ARROW_LENGTH,
+      );
+
+      if (loopResult != null) {
+        drawStyledPath(canvas, loopResult.path, currentPaint, lineType: lineType);
+
+        if (!noArrow) {
+          final trianglePaint = Paint()
+            ..color = edge.paint?.color ?? paint.color
+            ..style = PaintingStyle.fill;
+          final triangleCentroid = drawTriangle(
+            canvas,
+            trianglePaint,
+            loopResult.arrowBase.dx,
+            loopResult.arrowBase.dy,
+            loopResult.arrowTip.dx,
+            loopResult.arrowTip.dy,
+          );
+
+          drawStyledLine(
+            canvas,
+            loopResult.arrowBase,
+            triangleCentroid,
+            currentPaint,
+            lineType: lineType,
+          );
+        }
+
+        return;
+      }
+    }
+
     var sourceOffset = getNodePosition(source);
     var destinationOffset = getNodePosition(destination);
 
@@ -46,8 +84,6 @@ class ArrowEdgeRenderer extends EdgeRenderer {
         destination.width,
         destination.height);
 
-    final currentPaint = edge.paint ?? paint;
-
     if (noArrow) {
       // Draw line without arrow, respecting line type
       drawStyledLine(
@@ -55,7 +91,7 @@ class ArrowEdgeRenderer extends EdgeRenderer {
         Offset(clippedLine[0], clippedLine[1]),
         Offset(clippedLine[2], clippedLine[3]),
         currentPaint,
-        lineType: _getLineType(destination),
+        lineType: lineType,
       );
     } else {
       var trianglePaint = Paint()
@@ -84,7 +120,7 @@ class ArrowEdgeRenderer extends EdgeRenderer {
         Offset(clippedLine[0], clippedLine[1]),
         triangleCentroid,
         currentPaint,
-        lineType: _getLineType(destination),
+        lineType: lineType,
       );
     }
   }

--- a/lib/edgerenderer/EdgeRenderer.dart
+++ b/lib/edgerenderer/EdgeRenderer.dart
@@ -149,25 +149,45 @@ abstract class EdgeRenderer {
     }
 
     final node = edge.source;
-    final center = getNodeCenter(node);
-    final radius = max(node.width, node.height) * 0.5 + loopPadding;
-    final loopCenter = Offset(
-      center.dx + node.width * 0.5 + radius,
-      center.dy,
+    final nodePosition = getNodePosition(node);
+
+    final start = Offset(
+      nodePosition.dx + node.width,
+      nodePosition.dy + node.height * 0.5,
+    );
+
+    final end = Offset(
+      nodePosition.dx + node.width * 0.5,
+      nodePosition.dy,
+    );
+
+    final horizontalOffset = max(loopPadding + node.width * 0.4, 24.0);
+    final verticalOffset = max(loopPadding + node.height * 0.8, 32.0);
+
+    final controlPoint1 = Offset(
+      start.dx + horizontalOffset,
+      start.dy - verticalOffset,
+    );
+
+    final controlPoint2 = Offset(
+      end.dx + horizontalOffset * 0.6,
+      end.dy - verticalOffset,
     );
 
     final path = Path()
-      ..moveTo(center.dx + node.width * 0.5, center.dy)
-      ..arcTo(
-        Rect.fromCircle(center: loopCenter, radius: radius),
-        pi,
-        1.45 * pi,
-        false,
+      ..moveTo(start.dx, start.dy)
+      ..cubicTo(
+        controlPoint1.dx,
+        controlPoint1.dy,
+        controlPoint2.dx,
+        controlPoint2.dy,
+        end.dx,
+        end.dy,
       );
 
     final metrics = path.computeMetrics().toList();
     if (metrics.isEmpty) {
-      return LoopRenderResult(path, center, center);
+      return LoopRenderResult(path, start, end);
     }
 
     final metric = metrics.first;
@@ -185,8 +205,8 @@ abstract class EdgeRenderer {
 
     return LoopRenderResult(
       trimmedPath,
-      arrowBaseTangent?.position ?? center,
-      arrowTipTangent?.position ?? center,
+      arrowBaseTangent?.position ?? end,
+      arrowTipTangent?.position ?? end,
     );
   }
 }

--- a/lib/edgerenderer/EdgeRenderer.dart
+++ b/lib/edgerenderer/EdgeRenderer.dart
@@ -149,30 +149,22 @@ abstract class EdgeRenderer {
     }
 
     final node = edge.source;
-    final nodePosition = getNodePosition(node);
+    final nodeCenter = getNodeCenter(node);
 
-    final start = Offset(
-      nodePosition.dx + node.width,
-      nodePosition.dy + node.height * 0.5,
+    final anchorRadius = node.size.shortestSide * 0.5;
+
+    final start = nodeCenter + Offset(anchorRadius, 0);
+
+    final end = nodeCenter + Offset(0, -anchorRadius);
+
+    final loopRadius = max(
+      loopPadding + anchorRadius,
+      anchorRadius * 1.5,
     );
 
-    final end = Offset(
-      nodePosition.dx + node.width * 0.5,
-      nodePosition.dy,
-    );
+    final controlPoint1 = start + Offset(loopRadius, 0);
 
-    final horizontalOffset = max(loopPadding + node.width * 0.4, 24.0);
-    final verticalOffset = max(loopPadding + node.height * 0.8, 32.0);
-
-    final controlPoint1 = Offset(
-      start.dx + horizontalOffset,
-      start.dy - verticalOffset,
-    );
-
-    final controlPoint2 = Offset(
-      end.dx + horizontalOffset * 0.6,
-      end.dy - verticalOffset,
-    );
+    final controlPoint2 = end + Offset(0, -loopRadius);
 
     final path = Path()
       ..moveTo(start.dx, start.dy)

--- a/lib/layered/SugiyamaAlgorithm.dart
+++ b/lib/layered/SugiyamaAlgorithm.dart
@@ -1183,23 +1183,27 @@ class SugiyamaAlgorithm extends Algorithm {
 
   void restoreCycle() {
     graph.nodes.forEach((n) {
-      if (nodeData[n]!.isReversed) {
-        nodeData[n]!.reversed.forEach((target) {
-          final existingEdge = graph.getEdgeBetween(target, n);
-          if (existingEdge == null) {
-            return;
-          }
-          final existingData = this.edgeData[existingEdge];
-          final bendPoints = existingData?.bendPoints ?? <double>[];
-          this.edgeData.remove(existingEdge);
-          graph.removeEdgeFromPredecessor(target, n);
-          final edge = graph.addEdge(n, target);
-
-          final restoredData = existingData ?? SugiyamaEdgeData();
-          restoredData.bendPoints = bendPoints;
-          this.edgeData[edge] = restoredData;
-        });
+      final nodeInfo = nodeData[n];
+      if (nodeInfo == null || !nodeInfo.isReversed) {
+        return;
       }
+
+      for (final target in nodeInfo.reversed.toList()) {
+        final existingEdge = graph.getEdgeBetween(target, n);
+        if (existingEdge == null) {
+          continue;
+        }
+        final existingData = this.edgeData.remove(existingEdge);
+        final bendPoints = existingData?.bendPoints ?? <double>[];
+        graph.removeEdgeFromPredecessor(target, n);
+        final edge = graph.addEdge(n, target);
+
+        final restoredData = existingData ?? SugiyamaEdgeData();
+        restoredData.bendPoints = bendPoints;
+        this.edgeData[edge] = restoredData;
+      }
+
+      nodeInfo.reversed.clear();
     });
   }
 

--- a/lib/layered/SugiyamaAlgorithm.dart
+++ b/lib/layered/SugiyamaAlgorithm.dart
@@ -774,6 +774,12 @@ class SugiyamaAlgorithm extends Algorithm {
         break;
     }
 
+    if (coordinates.isEmpty) {
+      for (final node in graph.nodes) {
+        coordinates[node] = 0.0;
+      }
+    }
+
     // Get the minimum coordinate value
     var minValue = coordinates.values.reduce(min);
 
@@ -793,6 +799,10 @@ class SugiyamaAlgorithm extends Algorithm {
 
   void resolveOverlaps(Map<Node, double> coordinates) {
     for (var layer in layers) {
+      if (layer.isEmpty) {
+        continue;
+      }
+
       var layerNodes = List<Node>.from(layer);
       layerNodes.sort(
           (a, b) => nodeData[a]!.position.compareTo(nodeData[b]!.position));

--- a/lib/layered/SugiyamaEdgeRenderer.dart
+++ b/lib/layered/SugiyamaEdgeRenderer.dart
@@ -30,8 +30,41 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
           ..style = PaintingStyle.fill;
       }
 
-      var currentPaint = edge.paint ?? paint
+      var currentPaint = (edge.paint ?? paint)
         ..style = PaintingStyle.stroke;
+
+      if (edge.source == edge.destination) {
+        final loopResult = buildSelfLoopPath(
+          edge,
+          arrowLength: addTriangleToEdge ? ARROW_LENGTH : 0.0,
+        );
+
+        if (loopResult != null) {
+          final lineType = nodeData[edge.destination]?.lineType;
+          drawStyledPath(canvas, loopResult.path, currentPaint, lineType: lineType);
+
+          if (addTriangleToEdge) {
+            final triangleCentroid = drawTriangle(
+              canvas,
+              edgeTrianglePaint ?? trianglePaint,
+              loopResult.arrowBase.dx,
+              loopResult.arrowBase.dy,
+              loopResult.arrowTip.dx,
+              loopResult.arrowTip.dy,
+            );
+
+            drawStyledLine(
+              canvas,
+              loopResult.arrowBase,
+              triangleCentroid,
+              currentPaint,
+              lineType: lineType,
+            );
+          }
+
+          return;
+        }
+      }
 
       if (hasBendEdges(edge)) {
         _renderEdgeWithBendPoints(canvas, edge, currentPaint, edgeTrianglePaint ?? trianglePaint);

--- a/lib/tree/TreeEdgeRenderer.dart
+++ b/lib/tree/TreeEdgeRenderer.dart
@@ -19,6 +19,14 @@ class TreeEdgeRenderer extends EdgeRenderer {
     var node = edge.source;
     var child = edge.destination;
 
+    if (node == child) {
+      final loopPath = buildSelfLoopPath(edge, arrowLength: 0.0);
+      if (loopPath != null) {
+        drawStyledPath(canvas, loopPath.path, edgePaint, lineType: child.lineType);
+      }
+      return;
+    }
+
     final parentPos = getNodePosition(node);
     final childPos = getNodePosition(child);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: graphview
 description:  GraphView is used to display data in graph structures. It can display Tree layout, Directed and Layered graph. Useful for Family Tree, Hierarchy View.
-version: 1.5.0
+version: 1.5.1
 homepage: https://github.com/nabil6391/graphview
 
 environment:

--- a/test/graph_test.dart
+++ b/test/graph_test.dart
@@ -76,6 +76,17 @@ void main() {
       }
     });
 
+    test('Graph does not duplicate nodes for self loops', () {
+      final graph = Graph();
+      final node = Node.Id('self');
+
+      graph.addEdge(node, node);
+
+      expect(graph.nodes.length, 1);
+      expect(graph.edges.length, 1);
+      expect(graph.nodes.single, node);
+    });
+
     test('ArrowEdgeRenderer builds self-loop path', () {
       final renderer = ArrowEdgeRenderer();
       final node = Node.Id('self')

--- a/test/graph_test.dart
+++ b/test/graph_test.dart
@@ -75,5 +75,22 @@ void main() {
         expect(timeTaken < 100, true);
       }
     });
+
+    test('ArrowEdgeRenderer builds self-loop path', () {
+      final renderer = ArrowEdgeRenderer();
+      final node = Node.Id('self')
+        ..size = const Size(40, 40)
+        ..position = const Offset(100, 100);
+
+      final edge = Edge(node, node);
+      final result = renderer.buildSelfLoopPath(edge);
+
+      expect(result, isNotNull);
+
+      final metrics = result!.path.computeMetrics().toList();
+      expect(metrics, isNotEmpty);
+      expect(metrics.first.length, greaterThan(0));
+      expect(result.arrowTip, isNot(equals(const Offset(0, 0))));
+    });
   });
 }

--- a/test/graph_test.dart
+++ b/test/graph_test.dart
@@ -103,5 +103,22 @@ void main() {
       expect(metrics.first.length, greaterThan(0));
       expect(result.arrowTip, isNot(equals(const Offset(0, 0))));
     });
+
+    test('SugiyamaAlgorithm handles single node self loop', () {
+      final graph = Graph();
+      final node = Node.Id('self')
+        ..size = const Size(40, 40);
+
+      graph.addEdge(node, node);
+
+      final config = SugiyamaConfiguration()
+        ..nodeSeparation = 20
+        ..levelSeparation = 20;
+
+      final algorithm = SugiyamaAlgorithm(config);
+
+      expect(() => algorithm.run(graph, 0, 0), returnsNormally);
+      expect(graph.nodes.length, 1);
+    });
   });
 }

--- a/test/graph_test.dart
+++ b/test/graph_test.dart
@@ -100,8 +100,21 @@ void main() {
 
       final metrics = result!.path.computeMetrics().toList();
       expect(metrics, isNotEmpty);
-      expect(metrics.first.length, greaterThan(0));
+      final metric = metrics.first;
+      expect(metric.length, greaterThan(0));
       expect(result.arrowTip, isNot(equals(const Offset(0, 0))));
+
+      final tangentStart = metric.getTangentForOffset(0);
+      expect(tangentStart, isNotNull);
+      expect(tangentStart!.vector.dy.abs(),
+          lessThan(tangentStart.vector.dx.abs() * 0.1));
+      expect(tangentStart.vector.dx, greaterThan(0));
+
+      final tangentEnd = metric.getTangentForOffset(metric.length);
+      expect(tangentEnd, isNotNull);
+      expect(tangentEnd!.vector.dx.abs(),
+          lessThan(tangentEnd.vector.dy.abs() * 0.1));
+      expect(tangentEnd.vector.dy, greaterThan(0));
     });
 
     test('SugiyamaAlgorithm handles single node self loop', () {


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the graph rendering library, with a focus on better handling of self-loop edges (edges where a node connects to itself), improved edge rendering, and enhanced stability in layout algorithms. The most significant changes include the addition of robust support for self-loops in edge renderers, fixes for node duplication, and improvements to the Sugiyama layout algorithm. There are also updates to documentation and animation terminology for clarity.

### Self-loop and Edge Rendering Improvements

* Added comprehensive support for rendering self-loop edges in `ArrowEdgeRenderer`, `SugiyamaEdgeRenderer`, and `TreeEdgeRenderer`, including new geometry calculations and visual handling for arrows and paths. The new `buildSelfLoopPath` method in `EdgeRenderer` enables consistent rendering of loops across different edge types. [[1]](diffhunk://#diff-85fad9570cd68c8b5f017ad18a58445b93c24a8df896b4d8af67b8ce5a258fb8R31-R68) [[2]](diffhunk://#diff-ddb43bf334aa282a605038c9af581a4cb6994a8e9fcf1a9cfeb6c97212a2da4dR139-R211) [[3]](diffhunk://#diff-6277bc96da593923d9c51fd487c1fd1ca305fa8db0ee214e6a36d6e5b07afba9L33-R68) [[4]](diffhunk://#diff-811ae5c0dd64703d34f7f9ac4ab4146a758a9080c046a1cb4f5f9b4fd20b4020R22-R29)
* Fixed edge rendering logic to ensure paint styles and line types are consistently applied, especially for self-loops and styled edges. [[1]](diffhunk://#diff-85fad9570cd68c8b5f017ad18a58445b93c24a8df896b4d8af67b8ce5a258fb8L49-R94) [[2]](diffhunk://#diff-85fad9570cd68c8b5f017ad18a58445b93c24a8df896b4d8af67b8ce5a258fb8L87-R123) [[3]](diffhunk://#diff-6277bc96da593923d9c51fd487c1fd1ca305fa8db0ee214e6a36d6e5b07afba9L33-R68)

### Graph Data Structure and Animation Terminology

* Updated the `Graph` class to prevent node duplication when adding self-loop edges, ensuring that a node is only added once even if it references itself.
* Renamed camera animation variables and methods to use "pan" terminology for clarity and consistency in navigation-related features. [[1]](diffhunk://#diff-248d6d6d1d09f705e4ac17422a79962ae5ca20a071eab159d99d4df5340e50fbL358-R360) [[2]](diffhunk://#diff-248d6d6d1d09f705e4ac17422a79962ae5ca20a071eab159d99d4df5340e50fbL369-R369) [[3]](diffhunk://#diff-248d6d6d1d09f705e4ac17422a79962ae5ca20a071eab159d99d4df5340e50fbL397-R397) [[4]](diffhunk://#diff-248d6d6d1d09f705e4ac17422a79962ae5ca20a071eab159d99d4df5340e50fbL492-R507)

### Sugiyama Layout Algorithm Stability

* Improved the Sugiyama algorithm to handle edge reversal and restoration more robustly, including proper storage and restoration of edge metadata for cycles and feedback arcs. Also added logic to handle empty layers and single-node self-loops gracefully. [[1]](diffhunk://#diff-603b8b49dc7baa2bc0667235a18ec062f0c86125287bc9a7e1ae7268a5bebccfL93-R99) [[2]](diffhunk://#diff-603b8b49dc7baa2bc0667235a18ec062f0c86125287bc9a7e1ae7268a5bebccfR777-R782) [[3]](diffhunk://#diff-603b8b49dc7baa2bc0667235a18ec062f0c86125287bc9a7e1ae7268a5bebccfR802-R805) [[4]](diffhunk://#diff-603b8b49dc7baa2bc0667235a18ec062f0c86125287bc9a7e1ae7268a5bebccfL1184-R1216) [[5]](diffhunk://#diff-603b8b49dc7baa2bc0667235a18ec062f0c86125287bc9a7e1ae7268a5bebccfR1244-R1247)

### Documentation and Versioning

* Updated `CHANGELOG.md` and `pubspec.yaml` to reflect the new version (1.5.1), document fixes for zoom-to-fit with hidden nodes, and clarify animation/navigation terminology. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R4) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL21-R28) [[3]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L3-R3)

### Testing

* Added new tests to verify correct handling of self-loops in the graph structure, edge rendering, and the Sugiyama algorithm, ensuring no node duplication and correct path generation for self-loop edges.